### PR TITLE
CI: Docker build/push workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,58 @@
+name: Docker Image
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  workflow_dispatch:
+    inputs:
+      ref_tag:
+        description: 'Version tag to publish (e.g., v0.1.2)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+            type=raw,value=${{ inputs.ref_tag }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
-## [Unreleased]
+## [0.1.2] - 2025-08-29
 ### Fixed
 - chaos: compute_window_metrics used `xc` before assignment when auto-selecting `tau` for the `generic` modality; now center/scales prior to `tau` selection.
 - chaos: tuned `lyap_rosenstein` fitting window (`max_t` 0.2) to stabilize λ1 on periodic signals.

--- a/bcp/__init__.py
+++ b/bcp/__init__.py
@@ -2,5 +2,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "0.1.0"
-
+__version__ = "0.1.2"

--- a/docs/WS_BRIDGE.md
+++ b/docs/WS_BRIDGE.md
@@ -8,9 +8,27 @@ Quick Start
   - `pip install -e ".[ws]"`
 - Generate or point to NDJSON events (e.g., from the cardiac shim):
   - `bcp-shim-cardiac --fs 800 --window 5 --windows 18 --out_dir outputs`
+  - or the Vagus ENG demo (Sprint 1.3):
+    - `bcp-shim-vagus --fs 1000 --window 2.5 --windows 12 --out_dir outputs`
 - Run the bridge in replay mode and serve the demo page:
-  - `bcp-ws-bridge --events outputs/events.ndjson --mode replay --static`
+- `bcp-ws-bridge --events outputs/events.ndjson --mode replay --static`
   - WebSocket: `ws://127.0.0.1:8765/ws`
+  - Demo clients (when `--static`):
+    - Minimal: `http://127.0.0.1:8766/client.html`
+    - Quality tags: `http://127.0.0.1:8766/client_quality.html`
+    - Vagus (entrainment tags): `http://127.0.0.1:8766/client_vagus.html`
+
+### From a real NWB file (vagus)
+
+```bash
+# Emit NDJSON from an NWB/HDF5 ElectricalSeries (channel 0), 2s windows
+bcp-shim-vagus-nwb --nwb /path/to/session.nwb --channel 0 \
+  --window 2.0 --step 2.0 --out_dir outputs
+
+# Broadcast and open the Vagus viewer
+bcp-ws-bridge --events outputs/vagus_events_from_nwb.ndjson --mode replay --static
+# Open: http://127.0.0.1:8766/client_vagus.html
+```
   - Demo UI: `http://127.0.0.1:8766/client.html`
 
 Modes
@@ -27,4 +45,3 @@ Notes
 
 - Replace `bcp/tools/public/client.html` with your production UI; keep the WebSocket path `/ws` and the event schema.
 - This bridge is intentionally minimal and backend-agnostic; any NDJSON producer with the same schema will work.
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bioelectric-control-panel"
-version = "0.1.1"
+version = "0.1.2"
 description = "Bioelectric data ingestion, validation, and analysis service (FastAPI) and SDK"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -50,6 +50,8 @@ ws = [
 bcp-api = "bcp.cli:run_api"
 bcp-stream = "bcp.tools.stream:main"
 bcp-shim-cardiac = "bcp.tools.cardio_shim:main"
+bcp-shim-vagus = "bcp.tools.vagus_shim:main"
+bcp-shim-vagus-nwb = "bcp.tools.vagus_nwb_shim:main"
 bcp-ws-bridge = "bcp.tools.ws_bridge:main"
 
 [tool.black]


### PR DESCRIPTION
Adds a GitHub Actions workflow to build and push the Docker image to GHCR on tags (v*) and on main. Includes a manual trigger with an optional ref_tag input to publish a specific version tag (e.g., v0.1.2).